### PR TITLE
payment-hub-barebone bugfix: values.yaml - fix whitespace

### DIFF
--- a/helm/payment-hub-barebone/values.yaml
+++ b/helm/payment-hub-barebone/values.yaml
@@ -23,17 +23,17 @@ ph-ee-engine:
     #Single Node Solution
     clusterHealthCheckParams: "wait_for_status=yellow&timeout=100s" 
     master:
-        readinessProbe:
-          httpGet:
-            path: /_cluster/health?wait_for_status=yellow&timeout=5s
-            port: 9200
-          initialDelaySeconds: 30
-      data:
-        readinessProbe:
-          httpGet:
-            path: /_cluster/health?wait_for_status=yellow&timeout=5s
-            port: 9200
-          initialDelaySeconds: 30
+      readinessProbe:
+        httpGet:
+          path: /_cluster/health?wait_for_status=yellow&timeout=5s
+          port: 9200
+        initialDelaySeconds: 30
+    data:
+      readinessProbe:
+        httpGet:
+          path: /_cluster/health?wait_for_status=yellow&timeout=5s
+          port: 9200
+        initialDelaySeconds: 30
 
     esConfig:
       elasticsearch.yml: |


### PR DESCRIPTION
Looks like there's an indentation error in the payment-hub-barebone value.yaml

Currently during `helm install ph-bb .`
```
Error: INSTALLATION FAILED: cannot load values.yaml: error converting YAML to JSON: yaml: line 30: did not find expected key
```

After this patch installation succeeds, although I'm not familiar enough with the deployment to know if there are problems besides that