### PR TITLE
Fix elasticsearch in payment-hub-barebone

### DIFF
--- a/helm/payment-hub-barebone/values.yaml
+++ b/helm/payment-hub-barebone/values.yaml
@@ -58,12 +58,10 @@ ph-ee-engine:
 
     esConfig:
       elasticsearch.yml: |
-        discovery:
-          type: single-node
-          seed_hosts: ""
-        xpack:
-          security:
-          enabled: false
+        path:
+          data: /usr/share/elasticsearch/data
+        cluster:
+          initial_master_nodes: ph-ee-elasticsearch-0
 
     # Shrink default JVM heap.
     esJavaOpts: "-Xmx128m -Xms128m"


### PR DESCRIPTION
cluster.initial_master_nodes: pointed to ph-ee-elasticsearch-0. Without this, it fails to find a master and health checks fail

path.data: pointed to mount point.