### PR TITLE
SLCB bpmn renamed based on new specs

### DIFF
--- a/orchestration/feel/bulk_connector_slcb-DFSPID.bpmn
+++ b/orchestration/feel/bulk_connector_slcb-DFSPID.bpmn
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1ib8r5b" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.11.0">
-  <bpmn:process id="slcb-ibank-usa" name="SLCB" isExecutable="true">
+  <bpmn:process id="bulk_connector_slcb-gorilla" name="SLCB" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_0tf4rfr</bpmn:outgoing>
     </bpmn:startEvent>
@@ -98,7 +98,7 @@
     </bpmn:extensionElements>
   </bpmn:message>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="slcb-ibank-usa">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="bulk_connector_slcb-gorilla">
       <bpmndi:BPMNEdge id="Flow_16n4wpb_di" bpmnElement="reconciliationFailedRetryExhausted">
         <di:waypoint x="705" y="320" />
         <di:waypoint x="952" y="320" />


### PR DESCRIPTION
## Description

* Update the named of SLCB bpmn
PS: Now all the bulk connector BPMN names would follow this convention `bulk_connector_{MODE}-{dfspid}`, where `{MODE}` is placeholder for payment mode.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Design related bullet points or design document link related to this PR added in the description above. 

- [x] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Add required Swagger annotation and update API documentation with details of any API changes if applicable

- [x] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing
