### PR TITLE
fix for front-end back-end chart (removed superset)

### DIFF
--- a/helm/ph-ee-fin-back-end/Chart.yaml
+++ b/helm/ph-ee-fin-back-end/Chart.yaml
@@ -6,9 +6,9 @@ version: 1.0.0
 appVersion: "ph-ee-superset: v1.16.0; ph-ee-engine:v1.16.0; fin-engine: v1.0.0; operations: 1.0.0;"
 
 dependencies:
-- name: ph-ee-superset
-  repository: "https://fynarfin.io/images/superset/"
-  version: 0.2.0
+- name: ph-ee-engine
+  repository: "https://fynarfin.io/images/ph-ee-engine-1.7.2-SNAPSHOT/"
+  version: 1.7.2-SNAPSHOT
 - name: fin-engine
   repository: "https://fynarfin.io/images/fineract/"
   version: 1.0.0-SNAPSHOT

--- a/helm/ph-ee-fin-back-end/values.yaml
+++ b/helm/ph-ee-fin-back-end/values.yaml
@@ -1,77 +1,1006 @@
-ph-ee-superset:
-  ph-ee-engine:
+ph-ee-engine:
+  zeebe:
+    broker:
+      contactpoint: "zeebe-zeebe-gateway:26500"
+  zeebe-cluster-helm:
+    global:
+      elasticsearch:
+        host: "ph-ee-elasticsearch"
+    image:
+      repository: camunda/zeebe
+      tag: 1.1.0
 
-    # zeebe-operate-helm:
+    clusterSize: "1"
+    partitionCount: "1"
+    replicationFactor: "1"
+    JavaOpts: "-Xms8g -Xmx8g -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:MaxRAMPercentage=25.0 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+PrintFlagsFinal"
 
-    # elasticsearch:
-
-    # kibana:
-
-    # operations:
-
-    ph_ee_connector_ams_mifos:
-      imageTag: "v1.2.1"
-
-    ph_ee_connector_mojaloop:
-      imageTag: "v1.0.0"
-
-    # kafka:
-
-    channel:
-      imageTag: "v1.3.1"
-
-    operations_app:
-      imageTag: "v1.3.0"
-
-    operations_web:
+    elasticsearch:
+      enabled: false
+    kibana:
       enabled: false
 
-    ph_ee_connector_gsma:
-      imageTag: "v1.0.2"
+    extraInitContainers: |
+      - name: init-ph-ee-kafka-exporter
+        image: busybox:1.28
+        command: ['/bin/sh', '-c']
+        args: ['wget -O /exporters/ph-ee-kafka-exporter.jar "https://paymenthub-ee-dev.s3.us-east-2.amazonaws.com/jars/exporter-1.0.0-SNAPSHOT.jar"; ls -al /exporters/']
+        volumeMounts:
+        - name: exporters
+          mountPath: /exporters/
 
-    ph_ee_connector_slcb:
-      imageTag: "v1.1.1"
+  zeebe-operate-helm:
+    enabled: true
+    image:
+      repository: camunda/operate
+      tag: 1.1.0
+    global:
+      elasticsearch:
+        host: "ph-ee-elasticsearch"
+        clusterName: "ph-ee-elasticsearch"
+    ingress:
+      enabled: false
+      className: "kong"
+      path: /
+      host: operate.sandbox.fynarfin.io
+      tls:
+        - secretName: sandbox-secret
 
-    mpesa:
-      imageTag: "v1.3.0"
+  elasticsearch:
+    enabled: true
+    replicas: 1
+    imageTag: 7.16.3
+    minimumMasterNodes: 1
+    esConfig:
+      elasticsearch.yml: |
+        xpack.security.enabled: false
+        xpack.security.transport.ssl.enabled: false
+        xpack.security.transport.ssl.verification_mode: certificate
+        xpack.security.transport.ssl.keystore.path: /usr/share/elasticsearch/config/certs/elastic-certificates.p12
+        xpack.security.transport.ssl.truststore.path: /usr/share/elasticsearch/config/certs/elastic-certificates.p12
+        xpack.security.http.ssl.enabled: false
+        xpack.security.http.ssl.truststore.path: /usr/share/elasticsearch/config/certs/elastic-certificates.p12
+        xpack.security.http.ssl.keystore.path: /usr/share/elasticsearch/config/certs/elastic-certificates.p12
+    secretMounts:
+      - name: elastic-certificates
+        secretName: elastic-certificates
+        path: /usr/share/elasticsearch/config/certs
+    extraEnvs:
+      - name: ELASTIC_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: elastic-credentials
+            key: password
 
-    roster_connector:
-      imageTag: "v1.1.0"
+    #Single Node Solution
+    clusterHealthCheckParams: "wait_for_status=yellow&timeout=100s"
+    protocol: http
+    master:
+      readinessProbe:
+        httpGet:
+          allow-insecure: true
+          username: elastic
+          password: "{{ .Env.ELASTIC_PASSWORD }}"
+          path: /_cluster/health?wait_for_status=yellow&timeout=5s
+          port: 9200
+        initialDelaySeconds: 30
+    data:
+      readinessProbe:
+        httpGet:
+          allow-insecure: true
+          username: elastic
+          password: "{{ .Env.ELASTIC_PASSWORD }}"
+          path: /_cluster/health?wait_for_status=yellow&timeout=5s
+          port: 9200
+        initialDelaySeconds: 30
 
-    paygops_connector:
-      imageTag: "v1.4.0"
 
-    notifications:
-      imageTag: "v1.0.2"
 
-    connector_bulk:
-      imageTag: "v1.4.0"
+    # Shrink default JVM heap.
+    esJavaOpts: "-Xmx512m -Xms512m"
 
-    zeebe_ops:
-      imageTag: "v1.0.2"
+    # Allocate smaller chunks of memory per pod.
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "1024M"
+      limits:
+        cpu: "1000m"
+        memory: "1024M"
+    volumeClaimTemplate:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: "gp2"
+      resources:
+        requests:
+          storage: 10Gi
 
-    messagegateway:
-      imageTag: "v1.0.0"
+  kibana:
+    readinessProbe:
+      initialDelaySeconds: 45
+      timeoutSeconds: 15
+      successThreshold: 1
+    enabled: true
+    elasticsearchHosts: "http://ph-ee-elasticsearch:9200/"
+    imageTag: 7.16.3
+    kibanaConfig:
+      kibana.yml: |
+        monitoring.enabled: false
+        xpack.encryptedSavedObjects.encryptionKey: 5f4dcc3b5aa765d61d8327deb882cf99
+        server.ssl:
+          enabled: false
+          key: /usr/share/kibana/config/certs/elastic-certificate.pem
+          certificate: /usr/share/kibana/config/certs/elastic-certificate.pem
+        xpack.security.encryptionKey: ${KIBANA_ENCRYPTION_KEY}
+        elasticsearch.ssl:
+          certificateAuthorities: /usr/share/kibana/config/certs/elastic-certificate.pem
+          verificationMode: certificate
+    secretMounts:
+      - name: elastic-certificate-pem
+        secretName: elastic-certificate-pem
+        path: /usr/share/kibana/config/certs
+    extraEnvs:
+      - name: 'ELASTICSEARCH_USERNAME'
+        valueFrom:
+          secretKeyRef:
+            name: elastic-credentials
+            key: username
+      - name: 'ELASTICSEARCH_PASSWORD'
+        valueFrom:
+          secretKeyRef:
+            name: elastic-credentials
+            key: password
+      - name: 'KIBANA_ENCRYPTION_KEY'
+        valueFrom:
+          secretKeyRef:
+            name: kibana
+            key: encryptionkey
+    ingress:
+      enabled: true
+      className: "nginx"
+      pathtype: ImplementationSpecific
+      annotations:
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/ingress.class: kong
+      # kubernetes.io/tls-acme: "true"
+      hosts:
+        - host: analytics.sandbox.fynarfin.io
+          paths:
+            - path: /
+      tls:
+        - secretName: sandbox-secret
+      #    hosts:
+      #      - chart-example.local
 
-    importer_es:
-      imageTag: "v1.3.0"
+  operations:
+    enabled: true
 
-    importer_rdbms:
-      imageTag: "v1.2.0"
+  operationsmysql:
+    auth:
+      database: "tenants"
+      username: "mifos"
+      password: "password"
+      rootPassword: "ethieTieCh8ahv"
+    initdbScripts:
+      setup.sql: |-
+        CREATE DATABASE messagegateway;
+        CREATE DATABASE `lion`;
+        CREATE DATABASE `gorilla`;
+        GRANT ALL PRIVILEGES ON `lion`.* TO 'mifos';
+        GRANT ALL PRIVILEGES ON `gorilla`.* TO 'mifos';
+        GRANT ALL ON *.* TO 'root'@'%';
+        GRANT ALL PRIVILEGES ON messagegateway.* TO 'mifos';
 
-    # kong:
-  
-    # zeebe-operate:
+  ph_ee_connector_ams_mifos:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/ph-ee-ams"
+    imageTag: latest
+    SPRING_PROFILES_ACTIVE: "fin12"
+    hostname: "amsmifos.sandbox.fynarfin.io"
+    ams_local_enabled: true
+    ams_local_interop_host : "https://fynams.sandbox.fynarfin.io"
+    ams_local_customer_host : "https://fynams.sandbox.fynarfin.io"
+    ams_local_account_host : "https://fynams.sandbox.fynarfin.io"
+    ams_local_auth_host : "https://fynams.sandbox.fynarfin.io"
+    ams_local_loan_host : "https://fynams.sandbox.fynarfin.io/"
+    dfspids: "gorilla,rhino"
+    ## tenants properties have been moved to fin12
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    ingress:
+      enabled: true
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+      tls:
+        - secretName: sandbox-secret
+      path: "/"
+      backend:
+        service:
+          name: ph-ee-connector-ams-mifos
+          port:
+            number: 80
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
 
-    # mock-oracle:
+  ph_ee_connector_mojaloop:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/phee-mojaloop"
+    imageTag: "latest"
+    SPRING_PROFILES_ACTIVE: "bb"
+    hostname: "mojaloop.sandbox.fynarfin.io"
+    DFSPIDS: "gorilla,rhino"
+    switch:
+      quotes:
+        host: "http://quoting-service.sandbox.fynarfin.io"
+        service: "quoting-service.sandbox.fynarfin.io"
+      als:
+        host: "http://account-lookup-service.sandbox.fynarfin.io"
+        service: "account-lookup-service.local"
+      transfers:
+        host: "http://api-adapter.sandbox.fynarfin.io"
+        service: "api-adapter.sandbox.fynarfin.io"
+      transactions:
+        host: "http://ml-api-adapter.sandbox.fynarfin.io"
+        service: "ml-api-adapter.sandbox.fynarfin.io"
+      oracle:
+        host: "http://moja-simulator.sandbox.fynarfin.io"
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    ingress:
+      enabled: true
+      className: "nginx"
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+      tls:
+        - secretName: sandbox-secret
+      path: "/"
+      backend:
+        service:
+          name: ph-ee-connector-mojaloop-java
+          port:
+            number: 80
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
+
+  kafka:
+    enabled: true
+    image: "spotify/kafka"
+    advertised:
+      host: "kafka"
+      port: "9092"
+    limits:
+      cpu: "500m"
+      memory: "1G"
+    requests:
+      cpu: "100m"
+      memory: "512M"
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
+
+  channel:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/phee-channel"
+    imageTag: latest
+    SPRING_PROFILES_ACTIVE: "bb,tenants"
+    hostname: "channel.sandbox.fynarfin.io"
+    stub_hostname: "channel-gsma.sandbox.fynarfin.io"
+    DFSPIDS: "gorilla,lion"
+    operations:
+      url: "http://ops-bk.sandbox.fynarfin.io/api/v1"
+      authEnabled: false
+    tenantPrimary:
+      clientId: "mifos"
+      clientSecret: "password"
+      tenant: "rhino"
+    tenantSecondary:
+      clientId: "mifos"
+      clientSecret: "password"
+      tenant: "gorilla"
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    ingress:
+      enabled: true
+      className: "nginx"
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+      tls:
+        - secretName: sandbox-secret
+      path: "/"
+      backend:
+        service:
+          name: ph-ee-connector-channel
+          port:
+            number: 80
+      stub_backend:
+        service:
+          name: ph-ee-connector-channel
+          port:
+            number: 82
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
+
+
+  mockpayment:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/phee-mock-payment-schema"
+    imageTag: latest
+    SPRING_PROFILES_ACTIVE: "bb,tenants"
+    DFSPIDS: "gorilla,lion"
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
+
+
+  gsmachannel:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/phee-gsma-channel"
+    imageTag: latest
+    SPRING_PROFILES_ACTIVE: "bb"
+    DFSPIDS: "gorilla,lion"
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    ingress:
+      enabled: true
+      className: "nginx"
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+      tls:
+        - secretName: sandbox-secret
+      path: "/"
+      backend:
+        service:
+          name: ph-ee-connector-gsma-channel
+          port:
+            number: 80
+      stub_backend:
+        service:
+          name: ph-ee-connector-gsma-channel
+          port:
+            number: 82
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
+
+    gsmachannelsimulator:
+      enabled: true
+      image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/phee-gsma-channel-simulator"
+      imageTag: latest
+      SPRING_PROFILES_ACTIVE: "bb"
+      DFSPIDS: "gorilla,lion"
+      limits:
+        cpu: "500m"
+        memory: "512M"
+      requests:
+        cpu: "100m"
+        memory: "256M"
+      ingress:
+        enabled: true
+        className: "nginx"
+        annotations:
+          kubernetes.io/ingress.class: "nginx"
+        tls:
+          - secretName: sandbox-secret
+        path: "/"
+        backend:
+          service:
+            name: ph-ee-connector-gsma-channel-simulator
+            port:
+              number: 80
+        stub_backend:
+          service:
+            name: ph-ee-connector-gsma-channel-simulator
+            port:
+              number: 82
+      deployment:
+        annotations:
+          deployTime: "{{ .Values.deployTime }}"
+
+  operations_app:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/ph-ee-ops-bk"
+    imageTag: "latest"
+    SPRING_PROFILES_ACTIVE: "bb"
+    tenants: "gorilla,lion, phdefault"
+    hostname: "ops-bk.sandbox.fynarfin.io"
+    datasource:
+      username: "mifos"
+      password: "password"
+      host: "operationsmysql"
+      port: 3306
+      schema: "tenants"
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    ingress:
+      enabled: true
+      className: "kong"
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+        nginx.ingress.kubernetes.io/configuration-snippet: |
+          more_set_headers "Access-Control-Allow-Origin: *";
+          more_set_headers "Platform-TenantId: *";
+        nginx.ingress.kubernetes.io/cors-allow-credentials: 'true'
+        nginx.ingress.kubernetes.io/cors-allow-headers: >-
+          DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,Platform-TenantId
+        nginx.ingress.kubernetes.io/cors-allow-methods: PUT, GET, POST, OPTIONS, DELETE, PATCH
+        nginx.ingress.kubernetes.io/enable-cors: 'true'
+      tls:
+        - secretName: sandbox-secret
+      path: "/"
+      backend:
+        service:
+          name: ph-ee-operations-app
+          port:
+            number: 80
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
+
+  operations_web:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/phee-ops-web"
+    imageTag: "latest"
+    SPRING_PROFILES_ACTIVE: "bb"
+    hostname: "ops.sandbox.fynarfin.io"
+    webhost: "ops.sandbox.fynarfin.io"
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    ingress:
+      className: "kong"
+      enabled: true
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+        konghq.com/plugins: request-transformer,oidc,cors
+      tls:
+        - secretName: sandbox-secret
+      path: "/"
+      backend:
+        service:
+          name: ph-ee-operations-web
+          port:
+            number: 4200
+    deployment:
+      config: {}
+
+  identity:
+    hostname: "ops-bk.sandbox.fynarfin.io"
+
+  ph_ee_connector_gsma:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/phee-gsma"
+    imageTag: latest
+    SPRING_PROFILES_ACTIVE: "bb"
+    api:
+      channel: ""
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
+
+  ph_ee_connector_slcb:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/ph-ee-slcb"
+    imageTag: latest
+    SPRING_PROFILES_ACTIVE: "bb"
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
+
+  mpesa:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/ph-mpesa"
+    imageTag: latest
+    SPRING_PROFILES_ACTIVE: "bb"
+    hostname: "mpesa.sandbox.fynarfin.io"
+    tenant: "lion"
+    zeebe_broker_contactpoint: "zeebe-zeebe-gateway:26500"
+    callback_host: "https://mpesa.sandbox.fynarfin.io/"
+    retry_count: 3
+    api_timeout: 60000
+    channel:
+      host: "http://ph-ee-connector-channel"
+    paygops:
+      host: "http://ph-ee-connector-ams-paygops"
+    roster:
+      host: "http://ph-ee-connector-ams-roster"
+    accounts:
+      roster:
+        name: "roster"
+        business_short_code: "7385028"
+        till: "1234567"
+        auth_host: "https://sandbox.safaricom.co.ke/oauth/v1/generate"
+        api_host: "https://sandbox.safaricom.co.ke"
+        client_key: "0pLxbN83FrOl5Nd0Fh9Zi5BQlMxSL2n5"
+        client_secret: "YzuGNoJxeub8ZC6d"
+        pass_key: "bfb279f9aa9bdbcf158e97dd71a467cd2e0c893059b10f78e6b72ada1ed2c919"
+      paygops:
+        name: "paygops"
+        business_short_code: "668158"
+        till: "9347335"
+        auth_host: "https://sandbox.safaricom.co.ke/oauth/v1/generate"
+        api_host: "https://sandbox.safaricom.co.ke"
+        client_key: "0pLxbN83FrOl5Nd0Fh9Zi5BQlMxSL2n5"
+        client_secret: "YzuGNoJxeub8ZC6d"
+        pass_key: "bfb279f9aa9bdbcf158e97dd71a467cd2e0c893059b10f78e6b72ada1ed2c919"
+    paybill:
+      accountHoldingInstitutionId: "gorilla"
+      paygops:
+        business_short_code: "24322607"
+        currency: "KES"
+      roster:
+        business_short_code: "12345678"
+        currency: "KES"
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    ingress:
+      enabled: true
+      className: "nginx"
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+      tls:
+        - secretName: sandbox-secret
+      path: "/"
+      backend:
+        service:
+          name: ph-ee-connector-mpesa
+          port:
+            number: 80
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
+    skip:
+      enabled: false
+
+  roster_connector:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/phee-roster"
+    imageTag: latest
+    SPRING_PROFILES_ACTIVE: "bb"
+    ams:
+      local:
+        enabled: true
+    pesacore:
+      auth_header: "PaymentHub"
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
+
+  paygops_connector:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/phee-connector-ams-paygops"
+    imageTag: latest
+    SPRING_PROFILES_ACTIVE: "bb"
+    LOGGING_LEVEL_ROOT: "INFO"
+    ams:
+      local:
+        enabled: false
+    paygops:
+      authheader: "PaymentHubTest"
+      base_url: "https://feature-test1.paygops.com/"
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
+
+  notifications:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/ph-ee-notifications"
+    imageTag: latest
+    SPRING_PROFILES_ACTIVE: "bb"
+    hostname: "notifications.sandbox.fynarfin.io"
+    MESSAGEGATEWAYCONFIG_HOST: "message-gateway"
+    NOTIFICATION_LOCAL_HOST: "ph-ee-connector-notifications"
+    NOTIFICATION_SUCCESS_ENABLED: "false"
+    NOTIFICATION_FAILURE_ENABLED: "false"
+    zeebe_broker_contactpoint: "zeebe-zeebe-gateway:26500"
+    hostconfig:
+      host: "message-gateway"
+      port: 80
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    ingress:
+      enabled: true
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+      tls:
+        - secretName: sandbox-secret
+      path: "/"
+      backend:
+        service:
+          name: ph-ee-connector-notifications
+          port:
+            number: 80
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
+
+  connector_bulk:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/phee-bulk-processor"
+    imageTag: latest
+    tenants: "gorilla,lion"
+    hostname: "bulk-connector.sandbox.fynarfin.io"
+    aws:
+      region: "us-east-2"
+      access_key: "AKIAX32JM37TZOJ5AKFB"
+      secret_key: "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"
+    operations_app:
+      contactpoint: "https://ops-bk.sandbox.fynarfin.io/"
+      endpoints:
+        batch_transaction: "/api/v1/batch/transactions"
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    ingress:
+      enabled: true
+      className: "kong"
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+        konghq.com/plugins: cors
+      tls:
+        - secretName: sandbox-secret
+      path: "/"
+      backend:
+        service:
+          name: ph-ee-connector-bulk
+          port:
+            number: 80
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
+
+  zeebe_ops:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/phee-zeebe-ops"
+    imageTag: latest
+    hostname: "zeebeops.sandbox.fynarfin.io"
+    zeebe_broker_contactpoint: "zeebe-zeebe-gateway:26500"
+    elasticsearch_url: "http://ph-ee-elasticsearch:9200/"
+    elasticsearch_contactpoint: "ph-ee-elasticsearch:9200"
+    tenants: "gorilla,lion"
+    elasticsearch_sslverification: false
+    elasticsearch_security_enabled: false
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    ingress:
+      enabled: true
+      className: "nginx"
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+      tls:
+        - secretName: sandbox-secret
+      path: "/"
+      backend:
+        service:
+          name: ph-ee-zeebe-ops
+          port:
+            number: 80
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
+
+  messagegateway:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/phee-message-gateway"
+    imageTag: latest
+    secret:
+      value:
+        api_key: "eKiC1_JWdKy7eaTGQFHxXXjXjacr60W9Zntl"
+        project_id: "PJ5ff552ce01d2978c"
+    hostname: "messagegateway.sandbox.fynarfin.io"
+    CALLBACKCONFIG_HOST: "ph-ee-connector-notifications"
+    HOSTCONFIG_HOST: "message-gateway"
+    MYSQL_USERNAME: "mifos"
+    MYSQL_PASSWORD: "password"
+    DATASOURCE_URL: jdbc:mysql:thin://operationsmysql:3306/messagegateway
+    PROVIDERSOURCE_FROMDATABASE: "disabled"
+    PROVIDERSOURCE_FROMYML: "enabled"
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    ingress:
+      enabled: true
+      className: "nginx"
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+      tls:
+        - secretName: sandbox-secret
+      path: "/"
+      backend:
+        service:
+          name: message-gateway
+          port:
+            number: 80
+
+  importer_es:
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/ph-es-importer"
+    imageTag: latest
+    elasticsearch_sslverification: false
+    elasticsearch_security_enabled: false
+    importer_elasticsearch_url: "http://ph-ee-elasticsearch:9200/"
+    reporting:
+      enabled: true
+      fields:
+        amount: true
+        accountId: true
+        ams: true
+        clientCorrelationId: true
+        currency: true
+        customData: true
+        confirmationReceived: true
+        errorInformation: true
+        errorCode: false
+        errorDescription: true
+        externalId: true
+        initiator: false
+        initiatorType: false
+        isNotificationsFailureEnabled: false
+        isNotificationsSuccessEnabled: false
+        mpesaTransactionId: false
+        mpesaTransactionStatusRetryCount: false
+        originDate: false
+        partyLookupFailed: false
+        phoneNumber: true
+        processDefinitionKey: false
+        processInstanceKey: true
+        scenario: false
+        tenantId: false
+        timer: false
+        timestamp: true
+        transactionFailed: false
+        transactionId: false
+        transferCreateFailed: false
+        transferSettlementFailed: false
+        transferResponseCREATE: false
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+
+  importer_rdbms:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/phee-importer-rdbms"
+    imageTag: latest
+    LOGGING_LEVEL_ROOT: "DEBUG"
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    datasource:
+      username: "mifos"
+      password: "password"
+      host: "operationsmysql"
+      port: 3306
+      schema: "tenants"
+
+  kong:
+    enabled: true
+    image:
+      repository: revomatico/docker-kong-oidc
+      tag: "latest"
+    env:
+      plugins: "bundled,oidc"
+    admin:
+      enabled: true
+      http:
+        enabled: true
+      tls:
+        enabled: false
+      ingress:
+        enabled: true
+        ingressClassName: "kong"
+        hostname: admin-kong.sandbox.fynarfin.io
+    extraObjects:
+      - apiVersion: configuration.konghq.com/v1
+        kind: KongClusterPlugin
+        metadata:
+          name: request-transformer
+          annotations:
+            kubernetes.io/ingress.class: "kong"
+          labels:
+            global: "false"
+        disabled: false # optionally disable the plugin in Kong
+        plugin: request-transformer
+        config:
+          remove:
+            headers:
+              - cookie
+              - x-id-token
+      - apiVersion: configuration.konghq.com/v1
+        kind: KongClusterPlugin
+        metadata:
+          name: cors
+          annotations:
+            kubernetes.io/ingress.class: "kong"
+          labels:
+            global: "true"
+        disabled: false # optionally disable the plugin in Kong
+        plugin: cors
+        config:
+          origins:
+            - "*"
+          credentials: true
+          max_age: 3600
+          exposed_headers :
+            - "X-Auth-Token"
+          preflight_continue: false
+      - apiVersion: configuration.konghq.com/v1
+        kind: KongClusterPlugin
+        metadata:
+          name: oidc
+          annotations:
+            kubernetes.io/ingress.class: "kong"
+          labels:
+            global: "false"
+        disabled: false # optionally disable the plugin in Kong
+        plugin: oidc
+        config: # configuration for the plugin
+          client_id: kong-oidc
+          client_secret: xxxxxxxx  # Generated on keyCloak
+          realm: kong
+          discovery: https://keycloak.sandbox.fynarfin.io/auth/realms/kong-oidc/.well-known/openid-configuration
+          scope: openid
+
+  keycloak:
+    enabled: true
+    ingress:
+      enabled: true
+      ingressClassName: "kong"
+      rules:
+        - host: 'keycloak.sandbox.fynarfin.io'
+          paths:
+            - path: /
+              pathType: Prefix
+      tls: []
+    extraVolumes: |
+      - name: realm-secret
+        secret:
+          secretName: realm-secret
+    extraVolumeMounts: |
+      - name: realm-secret
+        mountPath: "/realm/"
+        readOnly: true
+    extraEnv: |
+      - name: KEYCLOAK_IMPORT
+        value: /realm/kong-keycloak-realm.json
+
+  wildcardhostname: "*.sandbox.fynarfin.io"
+
+  tls: "sandbox-secret"
+
+  zeebe-operate:
+    ingress:
+      enabled: true
+      hostname: "zeebeoperate.sandbox.fynarfin.io"
+      className: "kong"
+      annotations:
+        kubernetes.io/ingress.class: "kong"
+      tls:
+        - secretName: sandbox-secret
+      path: "/"
+      backend:
+        service:
+          name: "zeebe-operate"
+          port:
+            number: 80
+
+  mock-oracle:
+    enabled: true
+    replicas: 1
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/mock-asl-oracle"
+    imagePullPolicy: "Always"
+    hostname: "mockoracle.sandbox.fynarfin.io"
+    ingress:
+      enabled: true
+      path: "/"
+      className: "nginx"
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+      backend:
+        service:
+          name: mock-oracle
+          port:
+            number: 80
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
+
+  redis:
+    enabled: true
+    replica:
+      replicaCount: 0
+
+
+  # kong:
+
+  # zeebe-operate:
+
+  # mock-oracle:
 
 fin-engine:
+  mariadb:
+    enabled: false
+    fullnameOverride: fineract-mysql
+    auth:
+      username: "mifos"
+      password: "password"
+      rootPassword: "4ET6ywqlGt"
  
   #fineract: 
   
   communityapp:
     enabled: false
     
-operations: 
+#operations:
 
   # grafana:

--- a/helm/ph-ee-fin-front-end/Chart.yaml
+++ b/helm/ph-ee-fin-front-end/Chart.yaml
@@ -6,9 +6,9 @@ version: 1.0.0
 appVersion: "ph-ee-superset: v1.16.0; ph-ee-engine:v1.16.0; fin-engine: v1.0.0; operations: 1.0.0;"
 
 dependencies:
-- name: ph-ee-superset
-  repository: "https://fynarfin.io/images/superset/"
-  version: 0.2.0
+- name: ph-ee-engine
+  repository: "https://fynarfin.io/images/ph-ee-engine-1.7.2-SNAPSHOT/"
+  version: 1.7.2-SNAPSHOT
 - name: fin-engine
   repository: "https://fynarfin.io/images/fineract/"
   version: 1.0.0-SNAPSHOT

--- a/helm/ph-ee-fin-front-end/values.yaml
+++ b/helm/ph-ee-fin-front-end/values.yaml
@@ -1,82 +1,1023 @@
-ph-ee-superset:
-  ph-ee-engine:
-    
-    operations_web:
-      imageTag: "v1.3.1"
+ph-ee-engine:
+  zeebe:
+    broker:
+      contactpoint: "zeebe-zeebe-gateway:26500"
+  zeebe-cluster-helm:
+    global:
+      elasticsearch:
+        host: "ph-ee-elasticsearch"
+    image:
+      repository: camunda/zeebe
+      tag: 1.1.0
 
-    zeebe-operate-helm:
-       enabled: false
+    clusterSize: "1"
+    partitionCount: "1"
+    replicationFactor: "1"
+    JavaOpts: "-Xms8g -Xmx8g -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:MaxRAMPercentage=25.0 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+PrintFlagsFinal"
 
     elasticsearch:
-       enabled: false
+      enabled: false
+    kibana:
+      enabled: false
 
-    # kibana:
+    extraInitContainers: |
+      - name: init-ph-ee-kafka-exporter
+        image: busybox:1.28
+        command: ['/bin/sh', '-c']
+        args: ['wget -O /exporters/ph-ee-kafka-exporter.jar "https://paymenthub-ee-dev.s3.us-east-2.amazonaws.com/jars/exporter-1.0.0-SNAPSHOT.jar"; ls -al /exporters/']
+        volumeMounts:
+        - name: exporters
+          mountPath: /exporters/
 
+  zeebe-operate-helm:
+    enabled: true
+    image:
+      repository: camunda/operate
+      tag: 1.1.0
+    global:
+      elasticsearch:
+        host: "ph-ee-elasticsearch"
+        clusterName: "ph-ee-elasticsearch"
+    ingress:
+      enabled: false
+      className: "kong"
+      path: /
+      host: operate.sandbox.fynarfin.io
+      tls:
+        - secretName: sandbox-secret
+
+  elasticsearch:
+    enabled: true
+    replicas: 1
+    imageTag: 7.16.3
+    minimumMasterNodes: 1
+    esConfig:
+      elasticsearch.yml: |
+        xpack.security.enabled: false
+        xpack.security.transport.ssl.enabled: false
+        xpack.security.transport.ssl.verification_mode: certificate
+        xpack.security.transport.ssl.keystore.path: /usr/share/elasticsearch/config/certs/elastic-certificates.p12
+        xpack.security.transport.ssl.truststore.path: /usr/share/elasticsearch/config/certs/elastic-certificates.p12
+        xpack.security.http.ssl.enabled: false
+        xpack.security.http.ssl.truststore.path: /usr/share/elasticsearch/config/certs/elastic-certificates.p12
+        xpack.security.http.ssl.keystore.path: /usr/share/elasticsearch/config/certs/elastic-certificates.p12
+    secretMounts:
+      - name: elastic-certificates
+        secretName: elastic-certificates
+        path: /usr/share/elasticsearch/config/certs
+    extraEnvs:
+      - name: ELASTIC_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: elastic-credentials
+            key: password
+
+    #Single Node Solution
+    clusterHealthCheckParams: "wait_for_status=yellow&timeout=100s"
+    protocol: http
+    master:
+      readinessProbe:
+        httpGet:
+          allow-insecure: true
+          username: elastic
+          password: "{{ .Env.ELASTIC_PASSWORD }}"
+          path: /_cluster/health?wait_for_status=yellow&timeout=5s
+          port: 9200
+        initialDelaySeconds: 30
+    data:
+      readinessProbe:
+        httpGet:
+          allow-insecure: true
+          username: elastic
+          password: "{{ .Env.ELASTIC_PASSWORD }}"
+          path: /_cluster/health?wait_for_status=yellow&timeout=5s
+          port: 9200
+        initialDelaySeconds: 30
+
+
+
+    # Shrink default JVM heap.
+    esJavaOpts: "-Xmx512m -Xms512m"
+
+    # Allocate smaller chunks of memory per pod.
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "1024M"
+      limits:
+        cpu: "1000m"
+        memory: "1024M"
+    volumeClaimTemplate:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: "gp2"
+      resources:
+        requests:
+          storage: 10Gi
+
+  kibana:
+    readinessProbe:
+      initialDelaySeconds: 45
+      timeoutSeconds: 15
+      successThreshold: 1
+    enabled: true
+    elasticsearchHosts: "http://ph-ee-elasticsearch:9200/"
+    imageTag: 7.16.3
+    kibanaConfig:
+      kibana.yml: |
+        monitoring.enabled: false
+        xpack.encryptedSavedObjects.encryptionKey: 5f4dcc3b5aa765d61d8327deb882cf99
+        server.ssl:
+          enabled: false
+          key: /usr/share/kibana/config/certs/elastic-certificate.pem
+          certificate: /usr/share/kibana/config/certs/elastic-certificate.pem
+        xpack.security.encryptionKey: ${KIBANA_ENCRYPTION_KEY}
+        elasticsearch.ssl:
+          certificateAuthorities: /usr/share/kibana/config/certs/elastic-certificate.pem
+          verificationMode: certificate
+    secretMounts:
+      - name: elastic-certificate-pem
+        secretName: elastic-certificate-pem
+        path: /usr/share/kibana/config/certs
+    extraEnvs:
+      - name: 'ELASTICSEARCH_USERNAME'
+        valueFrom:
+          secretKeyRef:
+            name: elastic-credentials
+            key: username
+      - name: 'ELASTICSEARCH_PASSWORD'
+        valueFrom:
+          secretKeyRef:
+            name: elastic-credentials
+            key: password
+      - name: 'KIBANA_ENCRYPTION_KEY'
+        valueFrom:
+          secretKeyRef:
+            name: kibana
+            key: encryptionkey
+    ingress:
+      enabled: true
+      className: "nginx"
+      pathtype: ImplementationSpecific
+      annotations:
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/ingress.class: kong
+      # kubernetes.io/tls-acme: "true"
+      hosts:
+        - host: analytics.sandbox.fynarfin.io
+          paths:
+            - path: /
+      tls:
+        - secretName: sandbox-secret
+      #    hosts:
+      #      - chart-example.local
+
+  operations:
+    enabled: true
+
+  operationsmysql:
+    auth:
+      database: "tenants"
+      username: "mifos"
+      password: "password"
+      rootPassword: "ethieTieCh8ahv"
+    initdbScripts:
+      setup.sql: |-
+        CREATE DATABASE messagegateway;
+        CREATE DATABASE `lion`;
+        CREATE DATABASE `gorilla`;
+        GRANT ALL PRIVILEGES ON `lion`.* TO 'mifos';
+        GRANT ALL PRIVILEGES ON `gorilla`.* TO 'mifos';
+        GRANT ALL ON *.* TO 'root'@'%';
+        GRANT ALL PRIVILEGES ON messagegateway.* TO 'mifos';
+
+  ph_ee_connector_ams_mifos:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/ph-ee-ams"
+    imageTag: latest
+    SPRING_PROFILES_ACTIVE: "fin12"
+    hostname: "amsmifos.sandbox.fynarfin.io"
+    ams_local_enabled: true
+    ams_local_interop_host : "https://fynams.sandbox.fynarfin.io"
+    ams_local_customer_host : "https://fynams.sandbox.fynarfin.io"
+    ams_local_account_host : "https://fynams.sandbox.fynarfin.io"
+    ams_local_auth_host : "https://fynams.sandbox.fynarfin.io"
+    ams_local_loan_host : "https://fynams.sandbox.fynarfin.io/"
+    dfspids: "gorilla,rhino"
+    ## tenants properties have been moved to fin12
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    ingress:
+      enabled: true
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+      tls:
+        - secretName: sandbox-secret
+      path: "/"
+      backend:
+        service:
+          name: ph-ee-connector-ams-mifos
+          port:
+            number: 80
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
+
+  ph_ee_connector_mojaloop:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/phee-mojaloop"
+    imageTag: "latest"
+    SPRING_PROFILES_ACTIVE: "bb"
+    hostname: "mojaloop.sandbox.fynarfin.io"
+    DFSPIDS: "gorilla,rhino"
+    switch:
+      quotes:
+        host: "http://quoting-service.sandbox.fynarfin.io"
+        service: "quoting-service.sandbox.fynarfin.io"
+      als:
+        host: "http://account-lookup-service.sandbox.fynarfin.io"
+        service: "account-lookup-service.local"
+      transfers:
+        host: "http://api-adapter.sandbox.fynarfin.io"
+        service: "api-adapter.sandbox.fynarfin.io"
+      transactions:
+        host: "http://ml-api-adapter.sandbox.fynarfin.io"
+        service: "ml-api-adapter.sandbox.fynarfin.io"
+      oracle:
+        host: "http://moja-simulator.sandbox.fynarfin.io"
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    ingress:
+      enabled: true
+      className: "nginx"
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+      tls:
+        - secretName: sandbox-secret
+      path: "/"
+      backend:
+        service:
+          name: ph-ee-connector-mojaloop-java
+          port:
+            number: 80
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
+
+  kafka:
+    enabled: true
+    image: "spotify/kafka"
+    advertised:
+      host: "kafka"
+      port: "9092"
+    limits:
+      cpu: "500m"
+      memory: "1G"
+    requests:
+      cpu: "100m"
+      memory: "512M"
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
+
+  channel:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/phee-channel"
+    imageTag: latest
+    SPRING_PROFILES_ACTIVE: "bb,tenants"
+    hostname: "channel.sandbox.fynarfin.io"
+    stub_hostname: "channel-gsma.sandbox.fynarfin.io"
+    DFSPIDS: "gorilla,lion"
     operations:
-       enabled: false
+      url: "http://ops-bk.sandbox.fynarfin.io/api/v1"
+      authEnabled: false
+    tenantPrimary:
+      clientId: "mifos"
+      clientSecret: "password"
+      tenant: "rhino"
+    tenantSecondary:
+      clientId: "mifos"
+      clientSecret: "password"
+      tenant: "gorilla"
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    ingress:
+      enabled: true
+      className: "nginx"
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+      tls:
+        - secretName: sandbox-secret
+      path: "/"
+      backend:
+        service:
+          name: ph-ee-connector-channel
+          port:
+            number: 80
+      stub_backend:
+        service:
+          name: ph-ee-connector-channel
+          port:
+            number: 82
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
 
-    ph_ee_connector_ams_mifos:
-      enabled: false
 
-    ph_ee_connector_mojaloop:
-      enabled: false
+  mockpayment:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/phee-mock-payment-schema"
+    imageTag: latest
+    SPRING_PROFILES_ACTIVE: "bb,tenants"
+    DFSPIDS: "gorilla,lion"
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
 
-    kafka:
-      enabled: false
 
+  gsmachannel:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/phee-gsma-channel"
+    imageTag: latest
+    SPRING_PROFILES_ACTIVE: "bb"
+    DFSPIDS: "gorilla,lion"
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    ingress:
+      enabled: true
+      className: "nginx"
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+      tls:
+        - secretName: sandbox-secret
+      path: "/"
+      backend:
+        service:
+          name: ph-ee-connector-gsma-channel
+          port:
+            number: 80
+      stub_backend:
+        service:
+          name: ph-ee-connector-gsma-channel
+          port:
+            number: 82
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
+
+    gsmachannelsimulator:
+      enabled: true
+      image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/phee-gsma-channel-simulator"
+      imageTag: latest
+      SPRING_PROFILES_ACTIVE: "bb"
+      DFSPIDS: "gorilla,lion"
+      limits:
+        cpu: "500m"
+        memory: "512M"
+      requests:
+        cpu: "100m"
+        memory: "256M"
+      ingress:
+        enabled: true
+        className: "nginx"
+        annotations:
+          kubernetes.io/ingress.class: "nginx"
+        tls:
+          - secretName: sandbox-secret
+        path: "/"
+        backend:
+          service:
+            name: ph-ee-connector-gsma-channel-simulator
+            port:
+              number: 80
+        stub_backend:
+          service:
+            name: ph-ee-connector-gsma-channel-simulator
+            port:
+              number: 82
+      deployment:
+        annotations:
+          deployTime: "{{ .Values.deployTime }}"
+
+  operations_app:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/ph-ee-ops-bk"
+    imageTag: "latest"
+    SPRING_PROFILES_ACTIVE: "bb"
+    tenants: "gorilla,lion, phdefault"
+    hostname: "ops-bk.sandbox.fynarfin.io"
+    datasource:
+      username: "mifos"
+      password: "password"
+      host: "operationsmysql"
+      port: 3306
+      schema: "tenants"
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    ingress:
+      enabled: true
+      className: "kong"
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+        nginx.ingress.kubernetes.io/configuration-snippet: |
+          more_set_headers "Access-Control-Allow-Origin: *";
+          more_set_headers "Platform-TenantId: *";
+        nginx.ingress.kubernetes.io/cors-allow-credentials: 'true'
+        nginx.ingress.kubernetes.io/cors-allow-headers: >-
+          DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,Platform-TenantId
+        nginx.ingress.kubernetes.io/cors-allow-methods: PUT, GET, POST, OPTIONS, DELETE, PATCH
+        nginx.ingress.kubernetes.io/enable-cors: 'true'
+      tls:
+        - secretName: sandbox-secret
+      path: "/"
+      backend:
+        service:
+          name: ph-ee-operations-app
+          port:
+            number: 80
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
+
+  operations_web:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/phee-ops-web"
+    imageTag: "latest"
+    SPRING_PROFILES_ACTIVE: "bb"
+    hostname: "ops.sandbox.fynarfin.io"
+    webhost: "ops.sandbox.fynarfin.io"
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    ingress:
+      className: "kong"
+      enabled: true
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+        konghq.com/plugins: request-transformer,oidc,cors
+      tls:
+        - secretName: sandbox-secret
+      path: "/"
+      backend:
+        service:
+          name: ph-ee-operations-web
+          port:
+            number: 4200
+    deployment:
+      config: {}
+
+  identity:
+    hostname: "ops-bk.sandbox.fynarfin.io"
+
+  ph_ee_connector_gsma:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/phee-gsma"
+    imageTag: latest
+    SPRING_PROFILES_ACTIVE: "bb"
+    api:
+      channel: ""
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
+
+  ph_ee_connector_slcb:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/ph-ee-slcb"
+    imageTag: latest
+    SPRING_PROFILES_ACTIVE: "bb"
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
+
+  mpesa:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/ph-mpesa"
+    imageTag: latest
+    SPRING_PROFILES_ACTIVE: "bb"
+    hostname: "mpesa.sandbox.fynarfin.io"
+    tenant: "lion"
+    zeebe_broker_contactpoint: "zeebe-zeebe-gateway:26500"
+    callback_host: "https://mpesa.sandbox.fynarfin.io/"
+    retry_count: 3
+    api_timeout: 60000
     channel:
+      host: "http://ph-ee-connector-channel"
+    paygops:
+      host: "http://ph-ee-connector-ams-paygops"
+    roster:
+      host: "http://ph-ee-connector-ams-roster"
+    accounts:
+      roster:
+        name: "roster"
+        business_short_code: "7385028"
+        till: "1234567"
+        auth_host: "https://sandbox.safaricom.co.ke/oauth/v1/generate"
+        api_host: "https://sandbox.safaricom.co.ke"
+        client_key: "0pLxbN83FrOl5Nd0Fh9Zi5BQlMxSL2n5"
+        client_secret: "YzuGNoJxeub8ZC6d"
+        pass_key: "bfb279f9aa9bdbcf158e97dd71a467cd2e0c893059b10f78e6b72ada1ed2c919"
+      paygops:
+        name: "paygops"
+        business_short_code: "668158"
+        till: "9347335"
+        auth_host: "https://sandbox.safaricom.co.ke/oauth/v1/generate"
+        api_host: "https://sandbox.safaricom.co.ke"
+        client_key: "0pLxbN83FrOl5Nd0Fh9Zi5BQlMxSL2n5"
+        client_secret: "YzuGNoJxeub8ZC6d"
+        pass_key: "bfb279f9aa9bdbcf158e97dd71a467cd2e0c893059b10f78e6b72ada1ed2c919"
+    paybill:
+      accountHoldingInstitutionId: "gorilla"
+      paygops:
+        business_short_code: "24322607"
+        currency: "KES"
+      roster:
+        business_short_code: "12345678"
+        currency: "KES"
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    ingress:
+      enabled: true
+      className: "nginx"
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+      tls:
+        - secretName: sandbox-secret
+      path: "/"
+      backend:
+        service:
+          name: ph-ee-connector-mpesa
+          port:
+            number: 80
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
+    skip:
       enabled: false
 
+  roster_connector:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/phee-roster"
+    imageTag: latest
+    SPRING_PROFILES_ACTIVE: "bb"
+    ams:
+      local:
+        enabled: true
+    pesacore:
+      auth_header: "PaymentHub"
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
+
+  paygops_connector:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/phee-connector-ams-paygops"
+    imageTag: latest
+    SPRING_PROFILES_ACTIVE: "bb"
+    LOGGING_LEVEL_ROOT: "INFO"
+    ams:
+      local:
+        enabled: false
+    paygops:
+      authheader: "PaymentHubTest"
+      base_url: "https://feature-test1.paygops.com/"
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
+
+  notifications:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/ph-ee-notifications"
+    imageTag: latest
+    SPRING_PROFILES_ACTIVE: "bb"
+    hostname: "notifications.sandbox.fynarfin.io"
+    MESSAGEGATEWAYCONFIG_HOST: "message-gateway"
+    NOTIFICATION_LOCAL_HOST: "ph-ee-connector-notifications"
+    NOTIFICATION_SUCCESS_ENABLED: "false"
+    NOTIFICATION_FAILURE_ENABLED: "false"
+    zeebe_broker_contactpoint: "zeebe-zeebe-gateway:26500"
+    hostconfig:
+      host: "message-gateway"
+      port: 80
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    ingress:
+      enabled: true
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+      tls:
+        - secretName: sandbox-secret
+      path: "/"
+      backend:
+        service:
+          name: ph-ee-connector-notifications
+          port:
+            number: 80
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
+
+  connector_bulk:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/phee-bulk-processor"
+    imageTag: latest
+    tenants: "gorilla,lion"
+    hostname: "bulk-connector.sandbox.fynarfin.io"
+    aws:
+      region: "us-east-2"
+      access_key: "AKIAX32JM37TZOJ5AKFB"
+      secret_key: "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"
     operations_app:
-      enabled: false
+      contactpoint: "https://ops-bk.sandbox.fynarfin.io/"
+      endpoints:
+        batch_transaction: "/api/v1/batch/transactions"
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    ingress:
+      enabled: true
+      className: "kong"
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+        konghq.com/plugins: cors
+      tls:
+        - secretName: sandbox-secret
+      path: "/"
+      backend:
+        service:
+          name: ph-ee-connector-bulk
+          port:
+            number: 80
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
 
-    ph_ee_connector_gsma:
-      enabled: false
+  zeebe_ops:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/phee-zeebe-ops"
+    imageTag: latest
+    hostname: "zeebeops.sandbox.fynarfin.io"
+    zeebe_broker_contactpoint: "zeebe-zeebe-gateway:26500"
+    elasticsearch_url: "http://ph-ee-elasticsearch:9200/"
+    elasticsearch_contactpoint: "ph-ee-elasticsearch:9200"
+    tenants: "gorilla,lion"
+    elasticsearch_sslverification: false
+    elasticsearch_security_enabled: false
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    ingress:
+      enabled: true
+      className: "nginx"
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+      tls:
+        - secretName: sandbox-secret
+      path: "/"
+      backend:
+        service:
+          name: ph-ee-zeebe-ops
+          port:
+            number: 80
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
 
-    ph_ee_connector_slcb:
-      enabled: false
+  messagegateway:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/phee-message-gateway"
+    imageTag: latest
+    secret:
+      value:
+        api_key: "eKiC1_JWdKy7eaTGQFHxXXjXjacr60W9Zntl"
+        project_id: "PJ5ff552ce01d2978c"
+    hostname: "messagegateway.sandbox.fynarfin.io"
+    CALLBACKCONFIG_HOST: "ph-ee-connector-notifications"
+    HOSTCONFIG_HOST: "message-gateway"
+    MYSQL_USERNAME: "mifos"
+    MYSQL_PASSWORD: "password"
+    DATASOURCE_URL: jdbc:mysql:thin://operationsmysql:3306/messagegateway
+    PROVIDERSOURCE_FROMDATABASE: "disabled"
+    PROVIDERSOURCE_FROMYML: "enabled"
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    ingress:
+      enabled: true
+      className: "nginx"
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+      tls:
+        - secretName: sandbox-secret
+      path: "/"
+      backend:
+        service:
+          name: message-gateway
+          port:
+            number: 80
 
-    mpesa:
-      enabled: false
+  importer_es:
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/ph-es-importer"
+    imageTag: latest
+    elasticsearch_sslverification: false
+    elasticsearch_security_enabled: false
+    importer_elasticsearch_url: "http://ph-ee-elasticsearch:9200/"
+    reporting:
+      enabled: true
+      fields:
+        amount: true
+        accountId: true
+        ams: true
+        clientCorrelationId: true
+        currency: true
+        customData: true
+        confirmationReceived: true
+        errorInformation: true
+        errorCode: false
+        errorDescription: true
+        externalId: true
+        initiator: false
+        initiatorType: false
+        isNotificationsFailureEnabled: false
+        isNotificationsSuccessEnabled: false
+        mpesaTransactionId: false
+        mpesaTransactionStatusRetryCount: false
+        originDate: false
+        partyLookupFailed: false
+        phoneNumber: true
+        processDefinitionKey: false
+        processInstanceKey: true
+        scenario: false
+        tenantId: false
+        timer: false
+        timestamp: true
+        transactionFailed: false
+        transactionId: false
+        transferCreateFailed: false
+        transferSettlementFailed: false
+        transferResponseCREATE: false
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
 
-    roster_connector:
-      enabled: false
+  importer_rdbms:
+    enabled: true
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/phee-importer-rdbms"
+    imageTag: latest
+    LOGGING_LEVEL_ROOT: "DEBUG"
+    limits:
+      cpu: "500m"
+      memory: "512M"
+    requests:
+      cpu: "100m"
+      memory: "256M"
+    datasource:
+      username: "mifos"
+      password: "password"
+      host: "operationsmysql"
+      port: 3306
+      schema: "tenants"
 
-    paygops_connector:
-      enabled: false
+  kong:
+    enabled: true
+    image:
+      repository: revomatico/docker-kong-oidc
+      tag: "latest"
+    env:
+      plugins: "bundled,oidc"
+    admin:
+      enabled: true
+      http:
+        enabled: true
+      tls:
+        enabled: false
+      ingress:
+        enabled: true
+        ingressClassName: "kong"
+        hostname: admin-kong.sandbox.fynarfin.io
+    extraObjects:
+      - apiVersion: configuration.konghq.com/v1
+        kind: KongClusterPlugin
+        metadata:
+          name: request-transformer
+          annotations:
+            kubernetes.io/ingress.class: "kong"
+          labels:
+            global: "false"
+        disabled: false # optionally disable the plugin in Kong
+        plugin: request-transformer
+        config:
+          remove:
+            headers:
+              - cookie
+              - x-id-token
+      - apiVersion: configuration.konghq.com/v1
+        kind: KongClusterPlugin
+        metadata:
+          name: cors
+          annotations:
+            kubernetes.io/ingress.class: "kong"
+          labels:
+            global: "true"
+        disabled: false # optionally disable the plugin in Kong
+        plugin: cors
+        config:
+          origins:
+            - "*"
+          credentials: true
+          max_age: 3600
+          exposed_headers :
+            - "X-Auth-Token"
+          preflight_continue: false
+      - apiVersion: configuration.konghq.com/v1
+        kind: KongClusterPlugin
+        metadata:
+          name: oidc
+          annotations:
+            kubernetes.io/ingress.class: "kong"
+          labels:
+            global: "false"
+        disabled: false # optionally disable the plugin in Kong
+        plugin: oidc
+        config: # configuration for the plugin
+          client_id: kong-oidc
+          client_secret: xxxxxxxx  # Generated on keyCloak
+          realm: kong
+          discovery: https://keycloak.sandbox.fynarfin.io/auth/realms/kong-oidc/.well-known/openid-configuration
+          scope: openid
 
-    notifications:
-      enabled: false
+  keycloak:
+    enabled: true
+    ingress:
+      enabled: true
+      ingressClassName: "kong"
+      rules:
+        - host: 'keycloak.sandbox.fynarfin.io'
+          paths:
+            - path: /
+              pathType: Prefix
+      tls: []
+    extraVolumes: |
+      - name: realm-secret
+        secret:
+          secretName: realm-secret
+    extraVolumeMounts: |
+      - name: realm-secret
+        mountPath: "/realm/"
+        readOnly: true
+    extraEnv: |
+      - name: KEYCLOAK_IMPORT
+        value: /realm/kong-keycloak-realm.json
 
-    connector_bulk:
-      enabled: false
+  wildcardhostname: "*.sandbox.fynarfin.io"
 
-    zeebe_ops:
-      enabled: false
+  tls: "sandbox-secret"
 
-    messagegateway:
-      enabled: false
+  zeebe-operate:
+    ingress:
+      enabled: true
+      hostname: "zeebeoperate.sandbox.fynarfin.io"
+      className: "kong"
+      annotations:
+        kubernetes.io/ingress.class: "kong"
+      tls:
+        - secretName: sandbox-secret
+      path: "/"
+      backend:
+        service:
+          name: "zeebe-operate"
+          port:
+            number: 80
 
-    importer_es:
-      enabled: false
+  mock-oracle:
+    enabled: true
+    replicas: 1
+    image: "419830066942.dkr.ecr.ap-south-1.amazonaws.com/mock-asl-oracle"
+    imagePullPolicy: "Always"
+    hostname: "mockoracle.sandbox.fynarfin.io"
+    ingress:
+      enabled: true
+      path: "/"
+      className: "nginx"
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+      backend:
+        service:
+          name: mock-oracle
+          port:
+            number: 80
+    deployment:
+      annotations:
+        deployTime: "{{ .Values.deployTime }}"
 
-    importer_rdbms:
-      enabled: false
+  redis:
+    enabled: true
+    replica:
+      replicaCount: 0
 
-    # kong:
-  
-    # zeebe-operate:
-
-    # mock-oracle:
-      
 fin-engine:
- 
-  #communityapp:
-
+  mariadb:
+    fullnameOverride: fineract-mysql
+    auth:
+      username: "mifos"
+      password: "password"
+      rootPassword: "4ET6ywqlGt"
+  mysql:
+    enabled: true
+    image:
+      tag: "10.5.16-debian-11-r22"
+      debug: true
+    auth:
+      username: "mifos"
+      password: "password"
+      rootPassword: "4ET6ywqlGt"
+    initdbScripts:
+      setup.sql: |-
+        # create databases
+        CREATE DATABASE IF NOT EXISTS `fineract_tenants`;
+        CREATE DATABASE IF NOT EXISTS `fineract_default`;
+        # create root user and grant rights
+        GRANT ALL ON *.* TO 'root'@'%';
+        GRANT ALL PRIVILEGES ON `fineract_tenants`.* TO 'mifos';
+        GRANT ALL PRIVILEGES ON `fineract_default`.* TO 'mifos';
+    primary:
+      resources:
+        requests:
+          memory: "0.5Gi"
+          cpu: "500m"
+        limits:
+          memory: "2Gi"
+          cpu: "1000m"
   fineract:
     enabled: false
+  #communityapp:
     
-operations: 
+#operations:
 
   # grafana:
     


### PR DESCRIPTION
## Description
* Simplify the front-end and back-end charts by removing multi-level inheritance. Now both the charts are using ph-ee-engine directly.
* Uses the latest release of ph-ee-engine(1.7.2).

 _(Ignore if these details are present on the associated JIRA ticket)_

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Design related bullet points or design document link related to this PR added in the description above. 

- [ ] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Add required Swagger annotation and update API documentation with details of any API changes if applicable

- [x] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing
