### PR TITLE
De-duplicate and remove dead code from child Chart

### DIFF
--- a/helm/g2p-sandbox-fynarfin-SIT/Chart.yaml
+++ b/helm/g2p-sandbox-fynarfin-SIT/Chart.yaml
@@ -8,5 +8,5 @@ appVersion: 1.16.0
 
 dependencies:
 - name: ph-ee-g2psandbox
-  repository: https://fynarfin.io/images/ph-ee-g2psandbox-0.0.0
-  version: 0.0.0
+  repository: https://fynarfin.io/images/ph-ee-g2psandbox-1.0.0
+  version: 1.0.0

--- a/helm/g2p-sandbox-fynarfin-SIT/values.yaml
+++ b/helm/g2p-sandbox-fynarfin-SIT/values.yaml
@@ -1,344 +1,39 @@
-ph-ee-engine:
-  zeebe:
-    broker:
-      contactpoint: "zeebe-zeebe-gateway:26500"
+ph-ee-g2psandbox:
   zeebe-cluster-helm:
     enabled: true
-    global:
-      elasticsearch:
-        host: "ph-ee-elasticsearch"
-    image:
-      repository: camunda/zeebe
-      tag: 1.1.0
-    clusterSize: "1"
-    partitionCount: "1"
-    replicationFactor: "1"
-    JavaOpts: "-Xms8g -Xmx8g -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:MaxRAMPercentage=25.0 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+PrintFlagsFinal"
+
     elasticsearch:
       enabled: false
     kibana:
       enabled: false
-    extraInitContainers: |
-      - name: init-ph-ee-kafka-exporter
-        image: busybox:1.28
-        command: ['/bin/sh', '-c']
-        args: ['wget -O /exporters/ph-ee-kafka-exporter.jar "https://paymenthub-ee-dev.s3.us-east-2.amazonaws.com/jars/exporter-1.0.0-SNAPSHOT.jar"; ls -al /exporters/']
-        volumeMounts:
-        - name: exporters
-          mountPath: /exporters/
 
-  zeebe-operate-helm:
-    enabled: true
-    image:
-      repository: camunda/operate
-      tag: 1.1.0
-    global:
-      elasticsearch:
-        host: "ph-ee-elasticsearch"
-        clusterName: "ph-ee-elasticsearch"
-    ingress:
-      enabled: false
-      annotations: 
-        kubernetes.io/ingress.class: nginx      
-      path: /
-      host: operate.sandbox.fynarfin.io
-      tls:
-        enabled: true
+  # zeebe-operate-helm:
 
-  elasticsearch:
-    enabled: true
-    replicas: 1
-    imageTag: 7.16.3
-    minimumMasterNodes: 1
-    esConfig:
-      elasticsearch.yml: |
-        xpack.security.enabled: false
-        xpack.security.transport.ssl.enabled: false
-        xpack.security.transport.ssl.verification_mode: certificate
-        xpack.security.transport.ssl.keystore.path: /usr/share/elasticsearch/config/certs/elastic-certificates.p12
-        xpack.security.transport.ssl.truststore.path: /usr/share/elasticsearch/config/certs/elastic-certificates.p12
-        xpack.security.http.ssl.enabled: false
-        xpack.security.http.ssl.truststore.path: /usr/share/elasticsearch/config/certs/elastic-certificates.p12
-        xpack.security.http.ssl.keystore.path: /usr/share/elasticsearch/config/certs/elastic-certificates.p12
-    secretMounts:
-      - name: elastic-certificates
-        secretName: elastic-certificates
-        path: /usr/share/elasticsearch/config/certs
-    extraEnvs:
-      - name: ELASTIC_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: elastic-credentials
-            key: password
+  # kibana:
 
-    #Single Node Solution
-    clusterHealthCheckParams: "wait_for_status=yellow&timeout=100s"
-    protocol: http
-    master:
-      readinessProbe:
-        httpGet:
-          allow-insecure: true
-          username: elastic
-          password: "{{ .Env.ELASTIC_PASSWORD }}"
-          path: /_cluster/health?wait_for_status=yellow&timeout=5s
-          port: 9200
-        initialDelaySeconds: 30
-    data:
-      readinessProbe:
-        httpGet:
-          allow-insecure: true
-          username: elastic
-          password: "{{ .Env.ELASTIC_PASSWORD }}"
-          path: /_cluster/health?wait_for_status=yellow&timeout=5s
-          port: 9200
-        initialDelaySeconds: 30
-    # Shrink default JVM heap.
-    esJavaOpts: "-Xmx512m -Xms512m"
-    # Allocate smaller chunks of memory per pod.
-    resources:
-      requests:
-        cpu: "100m"
-        memory: "1024M"
-      limits:
-        cpu: "1000m"
-        memory: "1024M"
-    volumeClaimTemplate:
-      accessModes: [ "ReadWriteOnce" ]
-      storageClassName: "gp2"
-      resources:
-        requests:
-          storage: 10Gi
-
-  kibana:
-    readinessProbe:
-      initialDelaySeconds: 45
-      timeoutSeconds: 15
-      successThreshold: 1
-    enabled: true
-    protocol: http
-    imageTag: 7.16.3
-    kibanaConfig:
-      kibana.yml: |
-        monitoring.enabled: false
-        xpack.encryptedSavedObjects.encryptionKey: 5f4dcc3b5aa765d61d8327deb882cf99
-        server.ssl:
-          enabled: false
-          key: /usr/share/kibana/config/certs/elastic-certificate.pem
-          certificate: /usr/share/kibana/config/certs/elastic-certificate.pem
-        xpack.security.encryptionKey: ${KIBANA_ENCRYPTION_KEY}
-        elasticsearch.ssl:
-          certificateAuthorities: /usr/share/kibana/config/certs/elastic-certificate.pem
-          verificationMode: certificate
-    secretMounts:
-      - name: elastic-certificate-pem
-        secretName: elastic-certificate-pem
-        path: /usr/share/kibana/config/certs
-    extraEnvs:
-      - name: 'ELASTICSEARCH_USERNAME'
-        valueFrom:
-          secretKeyRef:
-            name: elastic-credentials
-            key: username
-      - name: 'ELASTICSEARCH_PASSWORD'
-        valueFrom:
-          secretKeyRef:
-            name: elastic-credentials
-            key: password
-      - name: 'KIBANA_ENCRYPTION_KEY'
-        valueFrom:
-          secretKeyRef:
-            name: kibana
-            key: encryptionkey
-    ingress:
-      enabled: true
-      className: "nginx"
-      pathtype: "Prefix"
-      annotations: {}
-        # kubernetes.io/ingress.class: nginx
-        # kubernetes.io/tls-acme: "true"       
-      hosts:
-        - host: analytics.sandbox.fynarfin.io
-          paths:
-            - path: /
-      #tls: []
-      #  - secretName: chart-example-tls
-      #    hosts:
-      #      - chart-example.local
-
-  operations:
-    enabled: true
-
-  operationsmysql:
-    auth:
-      database: "tenants"
-      username: "mifos"
-      password: "password"
-      rootPassword: "ethieTieCh8ahv"
-    initdbScripts:
-      setup.sql: |-
-        CREATE DATABASE messagegateway;
-        CREATE DATABASE `rhino`;
-        CREATE DATABASE `gorilla`;
-        GRANT ALL PRIVILEGES ON `rhino`.* TO 'mifos';
-        GRANT ALL PRIVILEGES ON `gorilla`.* TO 'mifos';
-        GRANT ALL ON *.* TO 'root'@'%';
-        GRANT ALL PRIVILEGES ON messagegateway.* TO 'mifos';
-
+  # operations:
+    
   ph_ee_connector_ams_mifos:
     enabled: true
-    imageTag: v1.2.2
-    imagePullPolicy: "Always"
-    SPRING_PROFILES_ACTIVE: "fin12,bb"
-    ams_local_enabled: true
-    ams_local_interop_host: "https://fynams.sandbox.fynarfin.io/"
-    ams_local_account_host: "https://fynams.sandbox.fynarfin.io/"
-    ams_local_customer_host: "https://fynams.sandbox.fynarfin.io/"
-    ams_local_auth_host: "https://fynams.sandbox.fynarfin.io/"
-    ams_local_loan_host : "https://fynams.sandbox.mifos.io/"
-    ingress:
-      enabled: true
-      annotations: 
-        kubernetes.io/ingress.class: nginx
-      tls:
-        - secretName: sandbox-secret
-      hosts:
-        - host: ams-mifos.sandbox.fynarfin.io          
-          paths: 
-          - path: "/"
-            backend:
-              service:
-                name: ph-ee-connector-ams-mifos
-                port:
-                  number: 80  
-    deployment:
-      annotations:
-        deployTime: "{{ .Values.deployTime }}"                    
+    imageTag: v1.2.2                   
 
   ph_ee_connector_mojaloop:
     enabled: true
-    DFSPIDS: "gorilla,lion"
-    ingress:
-      enabled: true
-      annotations: 
-        kubernetes.io/ingress.class: nginx      
-      tls:
-        - secretName: sandbox-secret
-      hosts:
-        - host: mojaloop.sandbox.fynarfin.io          
-          paths: 
-          - path: "/"
-            backend:
-              service:
-                name: ph-ee-connector-mojaloop-java
-                port:
-                  number: 80            
-    deployment:
-      annotations:
-        deployTime: "{{ .Values.deployTime }}"
 
-  kafka:
-    enabled: true
-    advertised:
-      host: "kafka"
-      port: "9092"
-    deployment:
-      annotations:
-        deployTime: "{{ .Values.deployTime }}"
+  # kafka:
 
   channel:
     enabled: true
-    imageTag: latest
-    SPRING_PROFILES_ACTIVE: "bb,tenants"
-    DFSPIDS: "rhino,gorilla"
-    operations:
-      url: "http://ops-bk.sandbox.fynarfin.io/api/v1"
-      authEnabled: false
-    tenantPrimary:
-      clientId: "mifos"
-      clientSecret: "password"
-      tenant: "rhino"
-    tenantSecondary:
-      clientId: "mifos"
-      clientSecret: "password"
-      tenant: "gorilla"
-    ingress:
-      enabled: true
-      annotations: 
-        kubernetes.io/ingress.class: nginx  
-      tls:
-        - secretName: sandbox-secret
-      hosts:
-        - host: channel.sandbox.fynarfin.io          
-          paths: 
-          - path: "/"
-            backend:
-              service:
-                name: "ph-ee-connector-channel"
-                port:
-                  number: 80
-        - host: channel-gsma.sandbox.fynarfin.io          
-          paths:          
-          - path: "/"
-            backend:
-              service:
-                name: "ph-ee-connector-channel-gsma"
-                port:
-                  number: 82
-    deployment:
-      annotations:
-        deployTime: "{{ .Values.deployTime }}"
 
   operations_app:
     enabled: true
-    imageTag: latest
     tenants: "rhino,gorilla"
-    ingress:
-      enabled: true
-      annotations: 
-        kubernetes.io/ingress.class: nginx  
-      tls:
-        - secretName: sandbox-secret
-      hosts:
-        - host: ops-bk.sandbox.fynarfin.io          
-          paths: 
-          - path: "/"
-            backend:
-              service:
-                name: "ph-ee-operations-app"
-                port:
-                  number: 80            
-    deployment:
-      annotations:
-        deployTime: "{{ .Values.deployTime }}"
 
   operations_web:
-    enabled: true
-    imageTag: latest
-    SPRING_PROFILES_ACTIVE: "bb"
-    ingress:
-      enabled: true
-      className: "kong"
-      tls:
-        - secretName: sandbox-secret
-      hosts:
-        - host: ops.sandbox.fynarfin.io          
-          paths: 
-          - path: "/"
-            backend:
-              service:
-                name: "ph-ee-operations-web"
-                port:
-                  number: 4200          
-  identity:
-    hostname: "ops-bk.sandbox.fynarfin.io"
+    enabled: true          
 
   ph_ee_connector_gsma:
     enabled: true
-    imageTag: latest
-    SPRING_PROFILES_ACTIVE: "bb"
-    deployment:
-      annotations:
-        deployTime: "{{ .Values.deployTime }}"
 
   ph_ee_connector_slcb:
     enabled: false
@@ -354,131 +49,39 @@ ph-ee-engine:
     
   notifications:
     enabled: true
-    imageTag: latest
     NOTIFICATION_FAILURE_ENABLED: "false"
-    ingress:
-      enabled: true
-      annotations: 
-        kubernetes.io/ingress.class: nginx  
-      tls:
-        - secretName: sandbox-secret
-      hosts:
-        - host: notifications.sandbox.fynarfin.io         
-          paths: 
-          - path: "/"
-            backend:
-              service:
-                name: "ph-ee-connector-notifications"
-                port:
-                  number: 80            
-    deployment:
-      annotations:
-        deployTime: "{{ .Values.deployTime }}"
 
   connector_bulk:
     enabled: true
-    imageTag: latest
     tenant: "rhino,gorilla"
     aws:
       region: "us-east-2"
       access_key: "AKIAX32JM37TZOJ5AKFB"
       secret_key: "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"
-    operations_app:
-      contactpoint: "https://ops-bk.sandbox.fynarfin.io/"
-      endpoints:
-        batch_transaction: "/api/v1/batch/transactions"
-    ingress:
-      enabled: true
-      annotations: 
-        konghq.com/plugins: request-transformer,oidc,cors
-      tls:
-      - secretName: sandbox-secret
-        hosts:
-          - bulk-connector.sandbox.mifos.io
-      path: "/"
-      backend:
-        service:
-          name: ph-ee-connector-bulk
-          port:
-            number: 80
-    deployment:
-      annotations:
-        deployTime: "{{ .Values.deployTime }}"
         
   zeebe_ops:
     enabled: true
-    imageTag: latest
     tenants: "rhino,gorilla"
-    ingress:
-      enabled: true
-      annotations: 
-        kubernetes.io/ingress.class: nginx  
-      tls:
-        - secretName: sandbox-secret
-      hosts:
-        - host: zeebeops.sandbox.fynarfin.io          
-          paths: 
-          - path: "/"
-            backend:
-              service:
-                name: "ph-ee-zeebe-ops"
-                port:
-                  number: 80            
-    deployment:
-      annotations:
-        deployTime: "{{ .Values.deployTime }}"
 
   messagegateway:
     enabled: true
-    imageTag: latest
     secret:
       value:
         api_key: "eKiC1_JWdKy7eaTGQFHxXXjXjacr60W9Zntl"
         project_id: "PJ5ff552ce01d2978c"
-    ingress:
-      enabled: true
-      annotations: 
-        kubernetes.io/ingress.class: nginx  
-      tls:
-        - secretName: sandbox-secret
-      hosts:
-        - host: messagegateway.sandbox.fynarfin.io       
-          paths: 
-          - path: "/"
-            backend:
-              service:
-                name: "message-gateway"
-                port:
-                  number: 80   
-    deployment:
-      annotations:
-        deployTime: "{{ .Values.deployTime }}"                           
-
+                          
   importer_es:
     enabled: true
-    imageTag: latest
-    reporting:
-      enabled: false
 
   importer_rdbms:
     enabled: true
-    imageTag: latest
 
   wildcardhostname: "*.sandbox.fynarfin.io"
   tls: ""
 
   keycloak:
     enabled: true
-    ingress:
-      enabled: true
-      ingressClassName: "kong"
-      rules:
-        - host: 'keycloak.sandbox.fynarfin.io'
-          paths:
-          - path: /
-            pathType: Prefix
-      tls: []
-    
+  
   kong:
     enabled: true
 
@@ -486,16 +89,3 @@ ph-ee-engine:
     enabled: true
     replica:
       replicaCount: 0
-  
-zeebe-operate:
-  ingress:
-    enabled: true
-    hostname: "zeebeoperate.sandbox.fynarfin.io"
-    annotations:
-      kubernetes.io/ingress.class: "nginx"
-    path: "/"
-    backend:
-      service:
-        name: "zeebe-operate"
-        port:
-          number: 80


### PR DESCRIPTION
(https://mifosforge.jira.com/browse/GOV-412) Description

* Service name duplicate code removed from child charts.
* Removed duplicate/dead code for Zeebe Cluster & Zeebe Operate & test. 
* Removed ES/Kibana duplicate configs (must have) including certs (should have - keep only in ph-ee-engine).
* Operations App/MySQL is being duplicated for reference. Removed this duplicate and kept this only in g2p sandbox chart. 
* Env variables (Fineract/AMS hosts and ML hosts) - PH EE Engine chart should use service names. G2P sandbox chart shouldn’t have duplicate and SIT chart shouldn’t have duplicates until we want to use ingresses for Fineract/ML. Contactpoints should use service names in parent charts.

 _(Ignore if these details are present on the associated JIRA ticket)_

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Design-related bullet points or design document links related to this PR are added in the description above. 

- [ ] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Add required Swagger annotation and update API documentation with details of any API changes if applicable

- [ ] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing
