### PR TITLE
[PHEE-484] g2p-sandbox-fynarfin-SIT is not using docker latest image

### DIFF
--- a/.circleci/services.txt
+++ b/.circleci/services.txt
@@ -1,0 +1,15 @@
+ph-ee-g2psandbox.ph-ee-engine.community-app.image docker.io/openmf/community-app
+ph-ee-g2psandbox.ph-ee-engine.ph_ee_connector_ams_mifos.image docker.io/openmf/ph-ee-connector-ams-mifos
+ph-ee-g2psandbox.ph-ee-engine.connector_bulk.image docker.io/openmf/ph-ee-bulk-processor
+ph-ee-g2psandbox.ph-ee-engine.importer_rdbms.image docker.io/openmf/ph-ee-importer-rdbms
+ph-ee-g2psandbox.ph-ee-engine.channel.image docker.io/openmf/ph-ee-connector-channel
+ph-ee-g2psandbox.ph-ee-engine.messagegateway.image docker.io/openmf/message-gateway
+ph-ee-g2psandbox.ph-ee-engine.ph_ee_connector_gsma.image docker.io/openmf/ph-ee-connector-gsma
+ph-ee-g2psandbox.ph-ee-engine.mockpayment.image docker.io/openmf/ph-ee-connector-mock-payment-schema
+ph-ee-g2psandbox.ph-ee-engine.ph_ee_connector_mojaloop.image docker.io/openmf/ph-ee-connector-mojaloop
+ph-ee-g2psandbox.ph-ee-engine.notifications.image docker.io/openmf/ph-ee-notifications
+ph-ee-g2psandbox.account_mapper.image docker.io/openmf/ph-ee-identity-account-mapper
+ph-ee-g2psandbox.ph-ee-engine.importer_es.image docker.io/openmf/ph-ee-importer-es
+ph-ee-g2psandbox.ph-ee-engine.operations_app.image docker.io/openmf/ph-ee-operations-app
+ph-ee-g2psandbox.ph-ee-engine.operations_web.image docker.io/openmf/ph-ee-operations-web
+ph-ee-g2psandbox.ph-ee-engine.vouchers.image docker.io/openmf/ph-ee-vouchers

--- a/helm/g2p-sandbox-fynarfin-SIT/values.yaml
+++ b/helm/g2p-sandbox-fynarfin-SIT/values.yaml
@@ -31,7 +31,8 @@ ph-ee-g2psandbox:
       
     ph_ee_connector_ams_mifos:
       enabled: true
-      imageTag: v1.2.2 
+      image: docker.io/openmf/ph-ee-connector-ams-mifos:latest
+      imageTag: v1.2.2
       deployment:
         annotations:
           rollme: '{{ randAlphaNum 5 | quote }}'
@@ -62,6 +63,7 @@ ph-ee-g2psandbox:
 
     ph_ee_connector_mojaloop:
       enabled: true
+      image: docker.io/openmf/ph-ee-connector-mojaloop:latest
       imageTag: "830df54849"
       ingress:
         enabled: true
@@ -81,6 +83,7 @@ ph-ee-g2psandbox:
 
     channel:
       enabled: true
+      image: docker.io/openmf/ph-ee-connector-channel:latest
       operations:
         url: "http://ops-bk.sandbox.fynarfin.io/api/v1"
       server:
@@ -117,6 +120,7 @@ ph-ee-g2psandbox:
 
     operations_app:
       enabled: true
+      image: docker.io/openmf/ph-ee-operations-app:latest
       tenants: "rhino,gorilla"
       deployment:
         annotations:
@@ -134,7 +138,8 @@ ph-ee-g2psandbox:
                     number: 80 
 
     operations_web:
-      enabled: true 
+      enabled: true
+      image: docker.io/openmf/ph-ee-operations-web:latest
       ingress:
         enabled: true
         annotations:
@@ -151,6 +156,7 @@ ph-ee-g2psandbox:
 
     ph_ee_connector_gsma:
       enabled: true
+      image: docker.io/openmf/ph-ee-connector-gsma:latest
       ingress:
         enabled: true  
 
@@ -168,6 +174,7 @@ ph-ee-g2psandbox:
       
     notifications:
       enabled: true
+      image: docker.io/openmf/ph-ee-notifications:latest
       NOTIFICATION_FAILURE_ENABLED: "false"
       ingress:
         enabled: true 
@@ -184,6 +191,7 @@ ph-ee-g2psandbox:
 
     connector_bulk:
       enabled: true
+      image: docker.io/openmf/ph-ee-bulk-processor:latest
       tenants: "rhino,gorilla"
       deployment:
         annotations:
@@ -230,6 +238,7 @@ ph-ee-g2psandbox:
 
     messagegateway:
       enabled: true
+      image: docker.io/openmf/message-gateway:latest
       secret:
         value:
           api_key: "eKiC1_JWdKy7eaTGQFHxXXjXjacr60W9Zntl"
@@ -248,14 +257,17 @@ ph-ee-g2psandbox:
                             
     importer_es:
       enabled: true
+      image: docker.io/openmf/ph-ee-importer-es:latest
 
     importer_rdbms:
       enabled: true
+      image: docker.io/openmf/ph-ee-importer-rdbms:latest
       aws:
         region: "ap-south-1"
     
     mockpayment:
       enabled: true
+      image: docker.io/openmf/ph-ee-connector-mock-payment-schema:latest
       ingress:
         enabled: true
         annotations:
@@ -297,6 +309,7 @@ ph-ee-g2psandbox:
 
     vouchers:
       enabled: true
+      image: docker.io/openmf/ph-ee-vouchers:latest
 
       voucher:
         hostname: "https://vouchers.sandbox.fynarfin.io"
@@ -333,6 +346,7 @@ ph-ee-g2psandbox:
 
   account_mapper:
     enabled: true
+    image: docker.io/openmf/ph-ee-identity-account-mapper:latest
     deployment:
       annotations:
         rollme: "{{ randAlphaNum 5 | quote }}"


### PR DESCRIPTION
## Description

[PHEE-484 g2p-sandbox-fynarfin-SIT is not using docker latest image](https://fynarfin.atlassian.net/browse/PHEE-484?atlOrigin=eyJpIjoiMWIxMjczYzI4ZWM0NDY2MDg2ZmMzZTM1NWM1NWFkZGQiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)
## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Design-related bullet points or design document links related to this PR are added in the description above. 

- [ ] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Add required Swagger annotation and update API documentation with details of any API changes if applicable

- [ ] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing
