### PR TITLE
[PHEE-667] Enable prometheus service monitor in chart 

### DIFF
--- a/helm/g2p-sandbox-fynarfin-SIT/values.yaml
+++ b/helm/g2p-sandbox-fynarfin-SIT/values.yaml
@@ -31,7 +31,11 @@ ph-ee-g2psandbox:
               - path: /
 
     operations:
-      
+
+    prometheusServiceMonitor:
+      ## @param prometheusServiceMonitor.enabled if true then a service monitor will be deployed, which allows an installed prometheus controller to scrape metrics from the deployed pods
+      enabled: true
+
     ph_ee_connector_ams_mifos:
       enabled: true
       image: docker.io/openmf/ph-ee-connector-ams-mifos:latest

--- a/helm/g2p-sandbox-fynarfin-SIT/values.yaml
+++ b/helm/g2p-sandbox-fynarfin-SIT/values.yaml
@@ -16,7 +16,12 @@ ph-ee-g2psandbox:
 
     global:
       DFSPIDS: "gorilla,rhino,wakanda,pluto,venus,jupiter"
-      
+
+    camunda-platform:
+      prometheusServiceMonitor:
+        ## @param prometheusServiceMonitor.enabled if true then a service monitor will be deployed, which allows an installed prometheus controller to scrape metrics from the deployed pods
+        enabled: true
+
     kibana:
       ingress:
         enabled: true
@@ -31,10 +36,6 @@ ph-ee-g2psandbox:
               - path: /
 
     operations:
-
-    prometheusServiceMonitor:
-      ## @param prometheusServiceMonitor.enabled if true then a service monitor will be deployed, which allows an installed prometheus controller to scrape metrics from the deployed pods
-      enabled: true
 
     ph_ee_connector_ams_mifos:
       enabled: true

--- a/helm/operations/values.yaml
+++ b/helm/operations/values.yaml
@@ -66,3 +66,7 @@ grafana:
         gnetId: 6417
         revision: 1
         datasource: Prometheus
+      zeebe:
+        gnetId: 5210
+        revision: 1
+        datasource: Prometheus


### PR DESCRIPTION
## Description

[PHEE-667 Enable prometheus service monitor in chart and export data in metri…](https://fynarfin.atlassian.net/browse/PHEE-667?atlOrigin=eyJpIjoiODI2MDg2NzUyYTg3NDZiOWI0ZjM5NDI0MGFkZjhmZGYiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!
- [ ] Followed the PR title naming convention mentioned above.

- [ ] Design-related bullet points or design document links related to this PR are added in the description above. 

- [ ] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Add required Swagger annotation and update API documentation with details of any API changes if applicable

- [ ] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing
