### PR TITLE
[PHEE-667] Enable prometheus service monitor in chart

### DIFF
--- a/helm/g2p-sandbox-fynarfin-SIT/values.yaml
+++ b/helm/g2p-sandbox-fynarfin-SIT/values.yaml
@@ -33,11 +33,10 @@ ph-ee-g2psandbox:
     operations:
 
     camunda-platform:
-      zeebe:
-        prometheus:
+      prometheus:
+        enabled: true
+        servicemonitor:
           enabled: true
-          servicemonitor:
-            enabled: true
           ## @param prometheusServiceMonitor.enabled if true then a service monitor will be deployed, which allows an installed prometheus controller to scrape metrics from the deployed pods
 
     ph_ee_connector_ams_mifos:

--- a/helm/g2p-sandbox-fynarfin-SIT/values.yaml
+++ b/helm/g2p-sandbox-fynarfin-SIT/values.yaml
@@ -33,10 +33,9 @@ ph-ee-g2psandbox:
     operations:
 
     camunda-platform:
-      PrometheusServiceMonitor:
+      prometheusServiceMonitor:
         enabled: true
         scrapeInterval: 10s
-          ## @param prometheusServiceMonitor.enabled if true then a service monitor will be deployed, which allows an installed prometheus controller to scrape metrics from the deployed pods
 
     ph_ee_connector_ams_mifos:
       enabled: true

--- a/helm/g2p-sandbox-fynarfin-SIT/values.yaml
+++ b/helm/g2p-sandbox-fynarfin-SIT/values.yaml
@@ -31,7 +31,12 @@ ph-ee-g2psandbox:
               - path: /
 
     operations:
-      
+
+    camunda-platform:
+      prometheusServiceMonitor:
+        ## @param prometheusServiceMonitor.enabled if true then a service monitor will be deployed, which allows an installed prometheus controller to scrape metrics from the deployed pods
+        enabled: true
+
     ph_ee_connector_ams_mifos:
       enabled: true
       image: docker.io/openmf/ph-ee-connector-ams-mifos:latest

--- a/helm/g2p-sandbox-fynarfin-SIT/values.yaml
+++ b/helm/g2p-sandbox-fynarfin-SIT/values.yaml
@@ -36,6 +36,8 @@ ph-ee-g2psandbox:
       prometheusServiceMonitor:
         enabled: true
         scrapeInterval: 10s
+        labels:
+          release: g2p-sandbox
 
     ph_ee_connector_ams_mifos:
       enabled: true

--- a/helm/g2p-sandbox-fynarfin-SIT/values.yaml
+++ b/helm/g2p-sandbox-fynarfin-SIT/values.yaml
@@ -34,9 +34,10 @@ ph-ee-g2psandbox:
 
     camunda-platform:
       zeebe:
-        prometheusServiceMonitor:
+        prometheus:
+          servicemonitor:
+            enabled: true
           ## @param prometheusServiceMonitor.enabled if true then a service monitor will be deployed, which allows an installed prometheus controller to scrape metrics from the deployed pods
-          enabled: true
 
     ph_ee_connector_ams_mifos:
       enabled: true

--- a/helm/g2p-sandbox-fynarfin-SIT/values.yaml
+++ b/helm/g2p-sandbox-fynarfin-SIT/values.yaml
@@ -33,9 +33,10 @@ ph-ee-g2psandbox:
     operations:
 
     camunda-platform:
-      prometheusServiceMonitor:
-        ## @param prometheusServiceMonitor.enabled if true then a service monitor will be deployed, which allows an installed prometheus controller to scrape metrics from the deployed pods
-        enabled: true
+      zeebe:
+        prometheusServiceMonitor:
+          ## @param prometheusServiceMonitor.enabled if true then a service monitor will be deployed, which allows an installed prometheus controller to scrape metrics from the deployed pods
+          enabled: true
 
     ph_ee_connector_ams_mifos:
       enabled: true

--- a/helm/g2p-sandbox-fynarfin-SIT/values.yaml
+++ b/helm/g2p-sandbox-fynarfin-SIT/values.yaml
@@ -33,11 +33,12 @@ ph-ee-g2psandbox:
     operations:
 
     camunda-platform:
+      zeebe:
       prometheusServiceMonitor:
         enabled: true
         scrapeInterval: 10s
         labels:
-          release: g2p-sandbox
+          release: operate
 
     ph_ee_connector_ams_mifos:
       enabled: true
@@ -286,7 +287,7 @@ ph-ee-g2psandbox:
                 service:
                   name: "ph-ee-connector-bulk"
                   port:
-                    number: 8443   
+                    number: 8443
           
     zeebe_ops:
       enabled: true

--- a/helm/g2p-sandbox-fynarfin-SIT/values.yaml
+++ b/helm/g2p-sandbox-fynarfin-SIT/values.yaml
@@ -33,10 +33,9 @@ ph-ee-g2psandbox:
     operations:
 
     camunda-platform:
-      prometheus:
+      PrometheusServiceMonitor:
         enabled: true
-        servicemonitor:
-          enabled: true
+        scrapeInterval: 10s
           ## @param prometheusServiceMonitor.enabled if true then a service monitor will be deployed, which allows an installed prometheus controller to scrape metrics from the deployed pods
 
     ph_ee_connector_ams_mifos:

--- a/helm/g2p-sandbox-fynarfin-SIT/values.yaml
+++ b/helm/g2p-sandbox-fynarfin-SIT/values.yaml
@@ -35,6 +35,7 @@ ph-ee-g2psandbox:
     camunda-platform:
       zeebe:
         prometheus:
+          enabled: true
           servicemonitor:
             enabled: true
           ## @param prometheusServiceMonitor.enabled if true then a service monitor will be deployed, which allows an installed prometheus controller to scrape metrics from the deployed pods

--- a/helm/operations/values.yaml
+++ b/helm/operations/values.yaml
@@ -5,6 +5,14 @@ prometheus:
       scrape_interval: 10s
     retention: "7d"
     retentionSize: "7GB"
+    static_configs:
+      - job_name: zeebe
+        scrape_interval: 15s
+        metrics_path: /actuator/prometheus
+        scheme: http
+        static_configs:
+          - targets:
+              - localhost:9600
 
 grafana:
   enabled: true
@@ -70,3 +78,15 @@ grafana:
         gnetId: 5210
         revision: 1
         datasource: Prometheus
+#      zeebe-overview:
+#        url: https://raw.githubusercontent.com/camunda/zeebe/main/monitor/grafana/zeebe-overview.json
+
+
+
+
+
+
+
+
+
+

--- a/helm/operations/values.yaml
+++ b/helm/operations/values.yaml
@@ -58,10 +58,6 @@ grafana:
         gnetId: 7187
         revision: 1
         datasource: Prometheus
-      kubernetes-pods:
-        gnetId: 6336
-        revision: 1
-        datasource: Prometheus
       kubernetes-cluster:
         gnetId: 6417
         revision: 1

--- a/helm/operations/values.yaml
+++ b/helm/operations/values.yaml
@@ -66,3 +66,7 @@ grafana:
         gnetId: 6417
         revision: 1
         datasource: Prometheus
+      zeebe:
+        gnetId: 5210
+        revision: 1
+        datasource: Prometheus

--- a/helm/operations/values.yaml
+++ b/helm/operations/values.yaml
@@ -62,9 +62,6 @@ grafana:
         gnetId: 6417
         revision: 1
         datasource: Prometheus
-#        Only few query working in below given Dashboard for Zeebe
-#      zeebe-overview:
-#        url: https://raw.githubusercontent.com/camunda/zeebe/main/monitor/grafana/zeebe-overview.json
 
 
 

--- a/helm/operations/values.yaml
+++ b/helm/operations/values.yaml
@@ -5,14 +5,6 @@ prometheus:
       scrape_interval: 10s
     retention: "7d"
     retentionSize: "7GB"
-    static_configs:
-      - job_name: zeebe
-        scrape_interval: 15s
-        metrics_path: /actuator/prometheus
-        scheme: http
-        static_configs:
-          - targets:
-              - localhost:9600
 
 grafana:
   enabled: true

--- a/helm/operations/values.yaml
+++ b/helm/operations/values.yaml
@@ -62,10 +62,7 @@ grafana:
         gnetId: 6417
         revision: 1
         datasource: Prometheus
-      zeebe:
-        gnetId: 5210
-        revision: 1
-        datasource: Prometheus
+#        Only few query working in below given Dashboard for Zeebe
 #      zeebe-overview:
 #        url: https://raw.githubusercontent.com/camunda/zeebe/main/monitor/grafana/zeebe-overview.json
 


### PR DESCRIPTION
## Description

[PHEE-667 Enable prometheus service monitor in chart and export data in metri…](https://fynarfin.atlassian.net/browse/PHEE-667?atlOrigin=eyJpIjoiMzBhZDBhNDk1ODIzNDE5YWIzNDQwNDZjMmM3MTBjZTgiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!
- [X] Followed the PR title naming convention mentioned above.

- [X] Design-related bullet points or design document links related to this PR are added in the description above. 

- [X] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [X] Create/update unit or integration tests for verifying the changes made.

- [X] Add required Swagger annotation and update API documentation with details of any API changes if applicable

<img width="1680" alt="Screenshot 2024-07-15 at 5 48 19 PM" src="https://github.com/user-attachments/assets/5476f5ba-c899-4ce1-8739-67a1dec22bcf">
<img width="1679" alt="Screenshot 2024-07-15 at 5 48 37 PM" src="https://github.com/user-attachments/assets/ad2684a8-ed34-417e-a3ec-2c30a25764af">
] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing
